### PR TITLE
Handle action returning `undefined`

### DIFF
--- a/src/cache.spec.ts
+++ b/src/cache.spec.ts
@@ -26,6 +26,15 @@ describe('RedisCache', () => {
       expect(result).toEqual({ type: 'value', value: mockValue });
     });
 
+    it('returns correct CachedResult when value is undefined', async () => {
+      const mockKey = 'testKey';
+      redisClient.hset(mockKey, 'type', 'value');
+
+      const result = await cache.get(mockKey);
+
+      expect(result).toEqual({ type: 'value' });
+    });
+
     it('returns correct CachedResult when key exists with type "error"', async () => {
       const mockKey = 'testKey';
       const mockError = 'some error';
@@ -57,6 +66,14 @@ describe('RedisCache', () => {
     it('successfully sets a value', async () => {
       const mockKey = 'testKey';
       const mockValue: CachedResult = { type: 'value', value: 'some value' };
+
+      await expect(cache.set(mockKey, mockValue)).resolves.toBeUndefined();
+      expect(await redisClient.hgetall(mockKey)).toEqual(mockValue);
+    });
+
+    it('successfully sets undefined value', async () => {
+      const mockKey = 'testKey';
+      const mockValue: CachedResult = { type: 'value' };
 
       await expect(cache.set(mockKey, mockValue)).resolves.toBeUndefined();
       expect(await redisClient.hgetall(mockKey)).toEqual(mockValue);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,7 +8,7 @@ export type CachedResult =
     }
   | {
       type: 'value'; // Represents a successful state with a corresponding serialized value.
-      value: string;
+      value?: string;
     };
 
 // Custom error class for handling Redis cache-related errors.
@@ -49,15 +49,14 @@ export class RedisCache {
         // If there's no type, the key doesn't exist in cache.
         return null;
       }
-      return type === 'error'
-        ? {
-            type: 'error',
-            error,
-          }
-        : {
-            type: 'value',
-            value,
-          };
+      if (type === 'error') {
+        return {
+          type: 'error',
+          error,
+        };
+      }
+
+      return value ? { type: 'value', value } : { type: 'value' };
     } catch (error) {
       throw new RedisCacheError('Failed to get cached result', key, error);
     }

--- a/src/executor.spec.ts
+++ b/src/executor.spec.ts
@@ -52,6 +52,17 @@ describe('IdempotentExecutor', () => {
     expect(action).toHaveBeenCalledTimes(2);
   });
 
+  it('should replay undefined value', async () => {
+    const action = jest.fn().mockResolvedValue(undefined);
+
+    const result1 = await executor.run('key1', action);
+    const result2 = await executor.run('key1', action);
+
+    expect(result1).toBe(undefined);
+    expect(result2).toBe(undefined);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
   it('should handle concurrent action runs with successful result', async () => {
     const action = jest
       .fn()

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -147,6 +147,13 @@ export class IdempotentExecutor {
               throw new ReplayedErrorWrapper(cachedError);
             }
 
+            if (cachedResult.value === undefined) {
+              // If `undefined` does not satisfy the type T,
+              // this means the action also broke the type contract.
+              // So, we're simply replaying this here too.
+              return undefined as T;
+            }
+
             try {
               // Parse and replay the cached result.
               return valueSerializer.deserialize(cachedResult.value);


### PR DESCRIPTION
This fixes a bug where if `action` returns `undefined` the executor could not replay the value because it turned into an empty string at the storage and could not be properly deserialized back into `undefined`.