### PR TITLE
Add `ignoreErrors` option to run method

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The `run` method is a core function of the `IdempotentExecutor`, responsible for
   - `onActionError`: A callback invoked when the action fails during execution.
   - `onSuccessReplay`: A callback invoked when a successful action is replayed.
   - `onErrorReplay`: A callback invoked when a failed action is replayed.
+  - `shouldIgnoreError`: A callback invoked when an error is encountered. If it returns `true`, the error will not be cached and will not be replayed.
 
 ### Serialization
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idempotency-redis",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idempotency-redis",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "redlock": "^5.0.0-beta.2",
@@ -25,6 +25,9 @@
         "prettier": "^3.2.5",
         "ts-jest": "^29.1.2",
         "typescript": "^5.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 <22.0.0"
       },
       "peerDependencies": {
         "ioredis": "5.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idempotency-redis",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Idempotency guarantee via Redis",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idempotency-redis",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Idempotency guarantee via Redis",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/executor.spec.ts
+++ b/src/executor.spec.ts
@@ -73,8 +73,12 @@ describe('IdempotentExecutor.run method', () => {
       const error = new Error('action failed');
       const action = jest.fn().mockRejectedValue(error);
 
-      await expect(executor.run('key1', action, { shouldIgnoreError: () => true })).rejects.toThrow(error);
-      await expect(executor.run('key1', action, { shouldIgnoreError: () => true })).rejects.toThrow(error);
+      await expect(
+        executor.run('key1', action, { shouldIgnoreError: () => true }),
+      ).rejects.toThrow(error);
+      await expect(
+        executor.run('key1', action, { shouldIgnoreError: () => true }),
+      ).rejects.toThrow(error);
 
       expect(action).toHaveBeenCalledTimes(2);
     });

--- a/src/executor.spec.ts
+++ b/src/executor.spec.ts
@@ -73,8 +73,8 @@ describe('IdempotentExecutor.run method', () => {
       const error = new Error('action failed');
       const action = jest.fn().mockRejectedValue(error);
 
-      await expect(executor.run('key1', action, { ignoreErrors: true })).rejects.toThrow(error);
-      await expect(executor.run('key1', action, { ignoreErrors: true })).rejects.toThrow(error);
+      await expect(executor.run('key1', action, { shouldIgnoreError: () => true })).rejects.toThrow(error);
+      await expect(executor.run('key1', action, { shouldIgnoreError: () => true })).rejects.toThrow(error);
 
       expect(action).toHaveBeenCalledTimes(2);
     });

--- a/src/executor.spec.ts
+++ b/src/executor.spec.ts
@@ -69,6 +69,16 @@ describe('IdempotentExecutor.run method', () => {
       expect(action).toHaveBeenCalledTimes(1);
     });
 
+    it('should handle action execution failure by caching but not replaying the error if ignoreError is true', async () => {
+      const error = new Error('action failed');
+      const action = jest.fn().mockRejectedValue(error);
+
+      await expect(executor.run('key1', action, { ignoreErrors: true })).rejects.toThrow(error);
+      await expect(executor.run('key1', action, { ignoreErrors: true })).rejects.toThrow(error);
+
+      expect(action).toHaveBeenCalledTimes(2);
+    });
+
     it('should replay undefined value', async () => {
       const action = jest.fn().mockResolvedValue(undefined);
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -125,11 +125,11 @@ export class IdempotentExecutor {
               return undefined as T;
             }
 
-          return this.replayCachedValue(
-            idempotencyKey,
-            valueSerializer,
-            cachedResult.value,
-            options?.onSuccessReplay,
+            return this.replayCachedValue(
+              idempotencyKey,
+              valueSerializer,
+              cachedResult.value,
+              options?.onSuccessReplay,
             );
           }
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -71,6 +71,7 @@ export class IdempotentExecutor {
    *    @property {(idempotencyKey: string, error: Error) => Error} options.onActionError - Optional. A callback that is invoked when the action fails during execution. It receives the idempotency key and the error that occurred, and should return the error to be thrown by the executor.
    *    @property {(idempotencyKey: string, value: T) => T} options.onSuccessReplay - Optional. A callback that is invoked when a successful action is replayed. It receives the idempotency key and the result of the action, and should return the result to be returned by the executor.
    *    @property {(idempotencyKey: string, error: Error) => Error} options.onErrorReplay - Optional. A callback that is invoked when a failed action is replayed. It receives the idempotency key and the error that occurred, and should return the error to be thrown by the executor.
+   *    @property {(error: Error) => boolean} options.shouldIgnoreError - Optional. A callback that is invoked when an error is encountered. If it returns `true`, the error will not be cached and will not be replayed.
    * @returns {Promise<T>} The result of the executed action.
    * @throws {IdempotentExecutorCriticalError} If saving the result to cache fails, potentially leading to non-idempotent executions.
    * @throws {IdempotentExecutorCacheError} If retrieving the cached result fails.

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -34,7 +34,7 @@ interface RunOptions<T> {
   timeout: number;
   valueSerializer: Serializer<T>;
   errorSerializer: Serializer<Error>;
-  ignoreErrors?: boolean;
+  shouldIgnoreError?: (error: Error) => boolean;
   onActionSuccess: (idempotencyKey: string, value: T) => T;
   onActionError: (idempotencyKey: string, error: Error) => Error;
   onSuccessReplay: (idempotencyKey: string, value: T) => T;


### PR DESCRIPTION
context: https://app.graphite.dev/github/pr/rye-com/checkout-core/2235/Fix-additional-invoices-being-generated-when-prepayment-in-voice-has-not-yet-been-paid#comment-PRRC_kwDOINoaxs52QkJi