### PR TITLE
Add `namespace` option

### DIFF
--- a/src/executor.spec.ts
+++ b/src/executor.spec.ts
@@ -695,7 +695,7 @@ describe('IdempotentExecutor.run method', () => {
 
       // Verify the cache key includes the namespace
       const cacheKey = await redisClient.hgetall(
-        'idempotent-executor-result:key1:test-namespace',
+        'idempotent-executor-result:test-namespace:key1',
       );
       expect(cacheKey.type).toBe('value');
       expect(cacheKey.value).toBe('"action result"');
@@ -721,10 +721,10 @@ describe('IdempotentExecutor.run method', () => {
 
       // Verify both cache entries exist
       const cacheKey1 = await redisClient.hgetall(
-        'idempotent-executor-result:same-key:namespace1',
+        'idempotent-executor-result:namespace1:same-key',
       );
       const cacheKey2 = await redisClient.hgetall(
-        'idempotent-executor-result:same-key:namespace2',
+        'idempotent-executor-result:namespace2:same-key',
       );
       expect(cacheKey1.type).toBe('value');
       expect(cacheKey1.value).toBe('"result1"');
@@ -772,7 +772,7 @@ describe('IdempotentExecutor.run method', () => {
         'idempotent-executor-result:same-key',
       );
       const cacheKeyWithNamespace = await redisClient.hgetall(
-        'idempotent-executor-result:same-key:test-namespace',
+        'idempotent-executor-result:test-namespace:same-key',
       );
       expect(cacheKeyWithoutNamespace.type).toBe('value');
       expect(cacheKeyWithoutNamespace.value).toBe('"result1"');
@@ -798,7 +798,7 @@ describe('IdempotentExecutor.run method', () => {
 
       // Verify the error cache key includes the namespace
       const cacheKey = await redisClient.hgetall(
-        'idempotent-executor-result:key1:error-namespace',
+        'idempotent-executor-result:error-namespace:key1',
       );
       expect(cacheKey.type).toBe('error');
       expect(cacheKey.error).toBeDefined();
@@ -824,10 +824,10 @@ describe('IdempotentExecutor.run method', () => {
 
       // Verify both error cache entries exist separately
       const cacheKey1 = await redisClient.hgetall(
-        'idempotent-executor-result:same-key:namespace1',
+        'idempotent-executor-result:namespace1:same-key',
       );
       const cacheKey2 = await redisClient.hgetall(
-        'idempotent-executor-result:same-key:namespace2',
+        'idempotent-executor-result:namespace2:same-key',
       );
       expect(cacheKey1.type).toBe('error');
       expect(cacheKey2.type).toBe('error');

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -45,7 +45,7 @@ interface RunOptions<T> {
  * Configuration options for the {@link IdempotentExecutor}.
  */
 interface IdempotentExecutorOptions {
-  /** This will be suffixed to all idempotency keys. */
+  /** This will be inserted after the prefix and before the idempotency key. */
   namespace?: string;
 }
 
@@ -102,7 +102,7 @@ export class IdempotentExecutor {
       options?.errorSerializer ?? new DefaultErrorSerializer();
     let cacheKey = `idempotent-executor-result:${idempotencyKey}`;
     if (this.options.namespace) {
-      cacheKey = `${cacheKey}:${this.options.namespace}`;
+      cacheKey = `idempotent-executor-result:${this.options.namespace}:${idempotencyKey}`;
     }
     const shouldIgnoreError = options?.shouldIgnoreError ?? (() => false);
     try {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -61,6 +61,7 @@ export class IdempotentExecutor {
    * Initializes a new instance of the IdempotentExecutor class.
    *
    * @param {Client} redis - The Redis client to be used for managing state and locks.
+   * @param {IdempotentExecutorOptions} options - Optional. Configuration options for the executor.
    */
   constructor(redis: Client, options: IdempotentExecutorOptions = {}) {
     this.redlock = new Redlock([redis]);


### PR DESCRIPTION
Hey Dima 👋

We had an incident caused by an idempotency key collision between two services. We thought adding a `namespace` option to the `IdempotentExecutor` constructor could be a good way to prevent this problem from occurring again.