### PR TITLE
Switch GitHub Actions to npm trusted publisher auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,14 +29,15 @@ jobs:
   publish-npm:
     needs: build-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Summary
- Fixes #12 
- Update the GitHub Actions publish workflow to follow Step 2 of the npm trusted publisher instructions, replacing the deprecated npm access token flow with the new trusted publisher mechanism and secrets.
- Ensure the workflow now authenticates via the configured trusted publisher credentials before publishing releases.