### PR TITLE
Add real Redis integration tests and CI service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ on:
 jobs:
   node:
     runs-on: ubuntu-latest
+    env:
+      REDIS_URL: redis://127.0.0.1:6379
+
+    services:
+      redis:
+        image: redis:7.2-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     strategy:
       matrix:

--- a/src/cache.integration.spec.ts
+++ b/src/cache.integration.spec.ts
@@ -1,0 +1,70 @@
+import Redis from 'ioredis';
+
+import { RedisCache } from './cache';
+
+const redisUrl = process.env.REDIS_URL;
+const describeWithRedis = redisUrl ? describe : describe.skip;
+
+describeWithRedis('RedisCache integration (real Redis)', () => {
+  let redisClient: Redis;
+  let cache: RedisCache;
+  const keyPrefix = `cache-integration:${Date.now()}:${Math.random()
+    .toString(16)
+    .slice(2)}`;
+
+  const key = (suffix: string): string => `${keyPrefix}:${suffix}`;
+
+  beforeAll(() => {
+    redisClient = new Redis(redisUrl as string);
+    cache = new RedisCache(redisClient);
+  });
+
+  afterAll(async () => {
+    await redisClient.quit();
+  });
+
+  it('stores and returns values using real Redis hashes', async () => {
+    const cacheKey = key('value');
+
+    await cache.set(cacheKey, {
+      type: 'value',
+      value: '"serialized-value"',
+    });
+
+    expect(await redisClient.hgetall(cacheKey)).toEqual({
+      type: 'value',
+      value: '"serialized-value"',
+    });
+    await expect(cache.get(cacheKey)).resolves.toEqual({
+      type: 'value',
+      value: '"serialized-value"',
+    });
+  });
+
+  it('stores undefined values without writing an empty field', async () => {
+    const cacheKey = key('undefined-value');
+
+    await cache.set(cacheKey, { type: 'value' });
+
+    expect(await redisClient.hgetall(cacheKey)).toEqual({ type: 'value' });
+    await expect(cache.get(cacheKey)).resolves.toEqual({ type: 'value' });
+  });
+
+  it('stores and returns serialized error payloads', async () => {
+    const cacheKey = key('error');
+
+    await cache.set(cacheKey, {
+      type: 'error',
+      error: '{"name":"Error","message":"boom"}',
+    });
+
+    await expect(cache.get(cacheKey)).resolves.toEqual({
+      type: 'error',
+      error: '{"name":"Error","message":"boom"}',
+    });
+  });
+
+  it('returns null when key does not exist', async () => {
+    await expect(cache.get(key('missing'))).resolves.toBeNull();
+  });
+});

--- a/src/executor.integration.spec.ts
+++ b/src/executor.integration.spec.ts
@@ -1,0 +1,75 @@
+import Redis from 'ioredis';
+
+import { IdempotentExecutor } from './executor';
+import { IdempotentExecutorUnknownError } from './executor.errors';
+
+const redisUrl = process.env.REDIS_URL;
+const describeWithRedis = redisUrl ? describe : describe.skip;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describeWithRedis('IdempotentExecutor integration (real Redis)', () => {
+  let redisClientOne: Redis;
+  let redisClientTwo: Redis;
+  let executorOne: IdempotentExecutor;
+  let executorTwo: IdempotentExecutor;
+  const keyPrefix = `executor-integration:${Date.now()}:${Math.random()
+    .toString(16)
+    .slice(2)}`;
+
+  const key = (suffix: string): string => `${keyPrefix}:${suffix}`;
+
+  beforeAll(() => {
+    redisClientOne = new Redis(redisUrl as string);
+    redisClientTwo = new Redis(redisUrl as string);
+    executorOne = new IdempotentExecutor(redisClientOne);
+    executorTwo = new IdempotentExecutor(redisClientTwo);
+  });
+
+  afterAll(async () => {
+    await Promise.all([redisClientOne.quit(), redisClientTwo.quit()]);
+  });
+
+  it('replays a single successful execution across independent executors', async () => {
+    let invocation = 0;
+    const action = jest.fn(async () => {
+      invocation += 1;
+      await sleep(300);
+      return `value-${invocation}`;
+    });
+
+    const [resultOne, resultTwo] = await Promise.all([
+      executorOne.run(key('success-replay'), action, { timeout: 2000 }),
+      executorTwo.run(key('success-replay'), action, { timeout: 2000 }),
+    ]);
+
+    expect(resultOne).toBe('value-1');
+    expect(resultTwo).toBe('value-1');
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('times out lock contenders and replays after the winner finishes', async () => {
+    const action = jest.fn(async () => {
+      await sleep(900);
+      return 'slow-action-result';
+    });
+    const idempotencyKey = key('lock-timeout');
+
+    const winner = executorOne.run(idempotencyKey, action, { timeout: 400 });
+    await sleep(50);
+
+    await expect(
+      executorTwo.run(idempotencyKey, action, { timeout: 400 }),
+    ).rejects.toBeInstanceOf(IdempotentExecutorUnknownError);
+    await expect(winner).resolves.toBe('slow-action-result');
+
+    const replayAction = jest.fn(async () => 'should-not-run');
+    await expect(
+      executorTwo.run(idempotencyKey, replayAction, { timeout: 400 }),
+    ).resolves.toBe('slow-action-result');
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(replayAction).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
Summary
- add Redis service to CI to run against a real containerized instance
- add integration suites for the cache and executor to validate locking/replay behavior on real Redis
- guard the new suites so they only run when `REDIS_URL` is populated (e.g., in CI)

Testing
- Not run (not requested)