### PR TITLE
Enforce JSONSerializer string output contract

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -331,6 +331,10 @@ export class IdempotentExecutor {
           type: 'error',
           error: errorSerializer.serialize(value),
         });
+      } else if (value === undefined) {
+        await this.cache.set(cacheKey, {
+          type: 'value',
+        });
       } else {
         await this.cache.set(cacheKey, {
           type: 'value',

--- a/src/serialization.spec.ts
+++ b/src/serialization.spec.ts
@@ -53,6 +53,12 @@ describe('JSONSerializer', () => {
       ),
     );
   });
+
+  it('should throw an error when serialization result is undefined', () => {
+    expect(() => serializer.serialize(undefined)).toThrow(
+      new SerializerError('Not JSON serializable'),
+    );
+  });
 });
 
 describe('DefaultErrorSerializer', () => {

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -64,8 +64,15 @@ export class JSONSerializer<T> implements Serializer<T> {
   serialize(value: T): string {
     try {
       // Assumes the value is already in a JSON serializable format.
-      return JSON.stringify(value);
+      const result = JSON.stringify(value);
+      if (typeof result !== 'string') {
+        throw new SerializerError('Not JSON serializable');
+      }
+      return result;
     } catch (err) {
+      if (err instanceof SerializerError) {
+        throw err;
+      }
       throw new SerializerError('Not JSON serializable', err);
     }
   }


### PR DESCRIPTION
Summary
- add a post-JSON.stringify check so JSONSerializer now throws SerializerError unless it returns a string
- surface the new guard via a regression test that expects undefined serialization to throw

Testing
- Not run (not requested)