### PR TITLE
Validate executor timeouts and normalize lock settings

### DIFF
--- a/src/executor.spec.ts
+++ b/src/executor.spec.ts
@@ -146,7 +146,9 @@ describe('IdempotentExecutor.run method', () => {
         const action = jest.fn().mockResolvedValue('action result');
 
         await expect(
-          executor.run(`invalid-timeout-${String(timeout)}`, action, { timeout }),
+          executor.run(`invalid-timeout-${String(timeout)}`, action, {
+            timeout,
+          }),
         ).rejects.toThrow(
           new RangeError(
             'Timeout must be a positive finite number in milliseconds',


### PR DESCRIPTION
Summary
- normalize the timeout passed to `IdempotentExecutor.run`, enforce positive finite milliseconds, and compute lock retry parameters with explicit integers
- extract shared constants for timeout defaults, retry delay, and extension buffer, and add comprehensive tests covering invalid values and the normalized settings

Testing
- Not run (not requested)