### PR TITLE
Bump package version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idempotency-redis",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idempotency-redis",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "redlock": "^5.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idempotency-redis",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Idempotency guarantee via Redis",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- update `package.json` and `package-lock.json` to publish version 1.5.0

## Testing
- Not run (not requested)